### PR TITLE
Fix trailing whitespace in hero section system status message

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -124,7 +124,7 @@ function Hero() {
         <div className={`${mono.className} text-[#ccfc14] text-xs mb-8 overflow-hidden`}>
           <pre className="opacity-40">
 {`╔═══════════════════════════════════════════════════════════════════════════════╗
-║ SYSTEM ONLINE :: NEURAL NETWORK ACTIVE :: SECURITY: COMPROMISED              ║
+║ SYSTEM ONLINE :: NEURAL NETWORK ACTIVE :: SECURITY: COMPROMISED               ║
 ╚═══════════════════════════════════════════════════════════════════════════════╝`}
           </pre>
         </div>


### PR DESCRIPTION
Removes trailing whitespace from the system status message in the hero section for cleaner formatting.